### PR TITLE
optimize EventBus

### DIFF
--- a/src/main/java/com/tkisor/nekojs/utils/event/CancellableEventBus.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/CancellableEventBus.java
@@ -10,12 +10,16 @@ import java.util.function.Predicate;
 public interface CancellableEventBus<E> extends EventBus<E> {
 
     static <E> CancellableEventBus<E> create(Class<E> eventType) {
-        return new CancellableEventBusImpl<>(eventType);
+        return new CancellableEventBusImpl<>(eventType, null);
     }
 
     EventListenerToken<E> listen(Predicate<E> listener);
 
     EventListenerToken<E> listen(byte priority, Predicate<E> listener);
+
+    /// @return `true` if there's listener that returns `true`, `false` otherwise
+    @Override
+    boolean post(E event);
 
     @Override
     default <E_ extends E> CancellableEventBus<E_> cast() {

--- a/src/main/java/com/tkisor/nekojs/utils/event/EventBus.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/EventBus.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 public interface EventBus<E> {
 
     static <E> EventBus<E> create(Class<E> eventType) {
-        return new EventBusImpl<>(eventType);
+        return new EventBusImpl<>(eventType, null);
     }
 
     Class<E> eventType();

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/CancellableEventBusImpl.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/CancellableEventBusImpl.java
@@ -4,7 +4,9 @@ import com.tkisor.nekojs.utils.event.CancellableEventBus;
 import com.tkisor.nekojs.utils.event.CommonPriority;
 import com.tkisor.nekojs.utils.event.EventListenerToken;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -14,8 +16,8 @@ import java.util.stream.Stream;
 public final class CancellableEventBusImpl<E>
     extends EventBusBase<E, Predicate<E>> implements CancellableEventBus<E> {
 
-    public CancellableEventBusImpl(Class<E> eventType) {
-        super(eventType);
+    public CancellableEventBusImpl(Class<E> eventType, Object key) {
+        super(eventType, key);
     }
 
     @Override
@@ -34,7 +36,7 @@ public final class CancellableEventBusImpl<E>
     }
 
     private static <E> Predicate<E> compile(Stream<Predicate<E>> predicateStream) {
-        var arr = (Predicate<E>[]) predicateStream.toArray(Predicate[]::new);
+        var arr = predicateStream.toArray((IntFunction<Predicate<E>[]>) Predicate[]::new);
         switch (arr.length) {
             case 0:
                 return (ignored) -> false;
@@ -47,15 +49,21 @@ public final class CancellableEventBusImpl<E>
                 var p2 = arr[1];
                 var p3 = arr[2];
                 return event -> p1.test(event) || p2.test(event) || p3.test(event);
-            default:
-                return event -> {
-                    for (var predicate : arr) {
-                        if (predicate.test(event)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                };
         }
+        if (Arrays.stream(arr).allMatch(NeverCancelListener.class::isInstance)) {
+            var consumer = EventBusImpl.compile(
+                Arrays.stream(arr)
+                    .map(pred -> ((NeverCancelListener<E>) pred).consumer())
+            );
+            return new NeverCancelListener<>(consumer);
+        }
+        return event -> {
+            for (var predicate : arr) {
+                if (predicate.test(event)) {
+                    return true;
+                }
+            }
+            return false;
+        };
     }
 }

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusBase.java
@@ -29,6 +29,10 @@ public abstract class EventBusBase<EVENT, LISTENER> {
         return eventType;
     }
 
+    public final boolean isEmpty() {
+        return tokens.isEmpty();
+    }
+
     public final EventListenerToken<EVENT> listen(LISTENER listener) {
         return listen(CommonPriority.NORMAL, listener);
     }

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusBase.java
@@ -3,6 +3,7 @@ package com.tkisor.nekojs.utils.event.impl;
 import com.tkisor.nekojs.utils.event.CommonPriority;
 import com.tkisor.nekojs.utils.event.EventListenerToken;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -15,10 +16,12 @@ import java.util.stream.Stream;
 public abstract class EventBusBase<EVENT, LISTENER> {
     private final Class<EVENT> eventType;
     private final List<EventListenerTokenImpl<EVENT, LISTENER>> tokens;
+    private final Object key;
     private volatile LISTENER built;
 
-    protected EventBusBase(Class<EVENT> eventType) {
+    protected EventBusBase(Class<EVENT> eventType, Object key) {
         this.eventType = Objects.requireNonNull(eventType);
+        this.key = key;
         this.tokens = new ArrayList<>();
     }
 
@@ -32,7 +35,7 @@ public abstract class EventBusBase<EVENT, LISTENER> {
 
     public final EventListenerToken<EVENT> listen(byte priority, LISTENER listener) {
         built = null;
-        var token = new EventListenerTokenImpl<>(eventType, priority, listener);
+        var token = new EventListenerTokenImpl<>(eventType, priority, listener, new WeakReference<>(key));
         tokens.add(token);
         return token;
     }

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusImpl.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/EventBusImpl.java
@@ -11,8 +11,8 @@ import java.util.stream.Stream;
  */
 public final class EventBusImpl<E> extends EventBusBase<E, Consumer<E>> implements EventBus<E> {
 
-    public EventBusImpl(Class<E> eventType) {
-        super(eventType);
+    public EventBusImpl(Class<E> eventType, Object key) {
+        super(eventType, key);
     }
 
     @Override
@@ -21,7 +21,7 @@ public final class EventBusImpl<E> extends EventBusBase<E, Consumer<E>> implemen
         return false;
     }
 
-    private static <E> Consumer<E> compile(Stream<Consumer<E>> consumerStream) {
+    static <E> Consumer<E> compile(Stream<Consumer<E>> consumerStream) {
         var arr = consumerStream.toArray((IntFunction<Consumer<E>[]>) Consumer[]::new);
         switch (arr.length) {
             case 0:

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/EventListenerTokenImpl.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/EventListenerTokenImpl.java
@@ -2,21 +2,23 @@ package com.tkisor.nekojs.utils.event.impl;
 
 import com.tkisor.nekojs.utils.event.EventListenerToken;
 
+import java.lang.ref.WeakReference;
 import java.util.Objects;
 
 /**
+ * @param key {@code null} if the bus who created this token is not a dispatched bus
  * @author ZZZank
  */
 public record EventListenerTokenImpl<EVENT, LISTENER>(
     Class<EVENT> eventType,
     byte priority,
-    LISTENER listener
+    LISTENER listener,
+    WeakReference<Object> key
 ) implements EventListenerToken<EVENT>, Comparable<EventListenerTokenImpl<EVENT, LISTENER>> {
 
-    public EventListenerTokenImpl(Class<EVENT> eventType, byte priority, LISTENER listener) {
-        this.eventType = Objects.requireNonNull(eventType);
-        this.priority = priority;
-        this.listener = Objects.requireNonNull(listener);
+    public EventListenerTokenImpl {
+        Objects.requireNonNull(eventType, "eventType == null");
+        Objects.requireNonNull(listener, "listener == null");
     }
 
     @Override

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchCancellableEventBusImpl.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchCancellableEventBusImpl.java
@@ -1,10 +1,10 @@
 package com.tkisor.nekojs.utils.event.impl.dispatch;
 
-import com.tkisor.nekojs.utils.event.CancellableEventBus;
 import com.tkisor.nekojs.utils.event.CommonPriority;
 import com.tkisor.nekojs.utils.event.EventListenerToken;
 import com.tkisor.nekojs.utils.event.dispatch.DispatchCancellableEventBus;
 import com.tkisor.nekojs.utils.event.dispatch.DispatchKey;
+import com.tkisor.nekojs.utils.event.impl.CancellableEventBusImpl;
 
 import java.util.Map;
 import java.util.function.Predicate;
@@ -12,20 +12,20 @@ import java.util.function.Predicate;
 /**
  * @author ZZZank
  */
-public final class DispatchCancellableEventBusImpl<E, K> extends DispatchEventBusBase<E, K, CancellableEventBus<E>>
+public final class DispatchCancellableEventBusImpl<E, K> extends DispatchEventBusBase<E, K, CancellableEventBusImpl<E>>
     implements DispatchCancellableEventBus<E, K> {
 
     public DispatchCancellableEventBusImpl(
         Class<E> eventType,
         DispatchKey<E, K> dispatchKey,
-        Map<K, CancellableEventBus<E>> dispatched
+        Map<K, CancellableEventBusImpl<E>> dispatched
     ) {
         super(eventType, dispatchKey, dispatched);
     }
 
     @Override
-    protected CancellableEventBus<E> createBus(Class<E> eventType) {
-        return CancellableEventBus.create(eventType);
+    protected CancellableEventBusImpl<E> createBus(Class<E> eventType, K key) {
+        return new CancellableEventBusImpl<>(eventType, key);
     }
 
     @Override
@@ -34,7 +34,7 @@ public final class DispatchCancellableEventBusImpl<E, K> extends DispatchEventBu
             return mainBus.listen(priority, listener);
         }
         return this.dispatched
-            .computeIfAbsent(key, ignored -> this.createBus(this.eventType()))
+            .computeIfAbsent(key, k -> this.createBus(this.eventType(), k))
             .listen(priority, listener);
     }
 

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
@@ -70,7 +70,11 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, 
         var key = (KEY) impl.key().get();
 
         var bus = this.dispatched.get(key);
-        return bus != null && bus.unregister(token);
+        var result = bus != null && bus.unregister(token);
+        if (result && bus.isEmpty()) {
+            this.dispatched.remove(key);
+        }
+        return result;
     }
 
     public boolean post(EVENT event, KEY key) {

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
@@ -81,6 +81,10 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBus<EVENT>> {
     }
 
     public boolean post(EVENT event) {
+        if (this.dispatched.isEmpty()) {
+            // skip dispatching if there's no registered dispatched listener
+            return mainBus.post(event);
+        }
         return post(event, this.dispatchKey.eventToKey(event));
     }
 }

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
@@ -4,6 +4,8 @@ import com.tkisor.nekojs.utils.event.CommonPriority;
 import com.tkisor.nekojs.utils.event.EventBus;
 import com.tkisor.nekojs.utils.event.EventListenerToken;
 import com.tkisor.nekojs.utils.event.dispatch.DispatchKey;
+import com.tkisor.nekojs.utils.event.impl.EventBusBase;
+import com.tkisor.nekojs.utils.event.impl.EventListenerTokenImpl;
 
 import java.util.Map;
 import java.util.Objects;
@@ -12,7 +14,7 @@ import java.util.function.Consumer;
 /**
  * @author ZZZank
  */
-abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBus<EVENT>> {
+abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, ?> & EventBus<EVENT>> {
     private final DispatchKey<EVENT, KEY> dispatchKey;
     protected final BUS mainBus;
     protected final Map<KEY, BUS> dispatched;
@@ -23,7 +25,7 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBus<EVENT>> {
         Map<KEY, BUS> dispatched
     ) {
         this.dispatchKey = Objects.requireNonNull(dispatchKey);
-        this.mainBus = createBus(eventType);
+        this.mainBus = createBus(eventType, null);
         this.dispatched = Objects.requireNonNull(dispatched);
     }
 
@@ -35,14 +37,14 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBus<EVENT>> {
         return dispatchKey;
     }
 
-    protected abstract BUS createBus(Class<EVENT> eventType);
+    protected abstract BUS createBus(Class<EVENT> eventType, KEY key);
 
     public EventListenerToken<EVENT> listen(KEY key, byte priority, Consumer<EVENT> listener) {
         if (key == null) {
             return mainBus.listen(priority, listener);
         }
         return this.dispatched
-            .computeIfAbsent(key, k -> createBus(this.eventType()))
+            .computeIfAbsent(key, k -> createBus(this.eventType(), k))
             .listen(priority, listener);
     }
 
@@ -59,12 +61,16 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBus<EVENT>> {
     }
 
     public boolean unregister(EventListenerToken<EVENT> token) {
-        if (mainBus.unregister(token)) {
-            return true;
+        var impl = (EventListenerTokenImpl<EVENT, ?>) token;
+        if (impl.key() == null) {
+            return mainBus.unregister(impl);
         }
-        return this.dispatched.values()
-            .stream()
-            .anyMatch(bus -> bus.unregister(token));
+
+        @SuppressWarnings("unchecked")
+        var key = (KEY) impl.key().get();
+
+        var bus = this.dispatched.get(key);
+        return bus != null && bus.unregister(token);
     }
 
     public boolean post(EVENT event, KEY key) {

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusBase.java
@@ -29,17 +29,17 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, 
         this.dispatched = Objects.requireNonNull(dispatched);
     }
 
-    public Class<EVENT> eventType() {
+    public final Class<EVENT> eventType() {
         return mainBus.eventType();
     }
 
-    public DispatchKey<EVENT, KEY> dispatchKey() {
+    public final DispatchKey<EVENT, KEY> dispatchKey() {
         return dispatchKey;
     }
 
     protected abstract BUS createBus(Class<EVENT> eventType, KEY key);
 
-    public EventListenerToken<EVENT> listen(KEY key, byte priority, Consumer<EVENT> listener) {
+    public final EventListenerToken<EVENT> listen(KEY key, byte priority, Consumer<EVENT> listener) {
         if (key == null) {
             return mainBus.listen(priority, listener);
         }
@@ -48,19 +48,19 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, 
             .listen(priority, listener);
     }
 
-    public EventListenerToken<EVENT> listen(KEY key, Consumer<EVENT> listener) {
+    public final EventListenerToken<EVENT> listen(KEY key, Consumer<EVENT> listener) {
         return listen(key, CommonPriority.NORMAL, listener);
     }
 
-    public EventListenerToken<EVENT> listen(Consumer<EVENT> listener) {
+    public final EventListenerToken<EVENT> listen(Consumer<EVENT> listener) {
         return listen(null, CommonPriority.NORMAL, listener);
     }
 
-    public EventListenerToken<EVENT> listen(byte priority, Consumer<EVENT> listener) {
+    public final EventListenerToken<EVENT> listen(byte priority, Consumer<EVENT> listener) {
         return listen(null, priority, listener);
     }
 
-    public boolean unregister(EventListenerToken<EVENT> token) {
+    public final boolean unregister(EventListenerToken<EVENT> token) {
         var impl = (EventListenerTokenImpl<EVENT, ?>) token;
         if (impl.key() == null) {
             return mainBus.unregister(impl);
@@ -77,7 +77,7 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, 
         return result;
     }
 
-    public boolean post(EVENT event, KEY key) {
+    public final boolean post(EVENT event, KEY key) {
         if (mainBus.post(event)) {
             return true;
         }
@@ -90,7 +90,7 @@ abstract class DispatchEventBusBase<EVENT, KEY, BUS extends EventBusBase<EVENT, 
         return false;
     }
 
-    public boolean post(EVENT event) {
+    public final boolean post(EVENT event) {
         if (this.dispatched.isEmpty()) {
             // skip dispatching if there's no registered dispatched listener
             return mainBus.post(event);

--- a/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusImpl.java
+++ b/src/main/java/com/tkisor/nekojs/utils/event/impl/dispatch/DispatchEventBusImpl.java
@@ -1,21 +1,21 @@
 package com.tkisor.nekojs.utils.event.impl.dispatch;
 
-import com.tkisor.nekojs.utils.event.EventBus;
 import com.tkisor.nekojs.utils.event.dispatch.DispatchKey;
 import com.tkisor.nekojs.utils.event.dispatch.DispatchEventBus;
+import com.tkisor.nekojs.utils.event.impl.EventBusImpl;
 
 import java.util.Map;
 
 /**
  * @author ZZZank
  */
-public final class DispatchEventBusImpl<E, K> extends DispatchEventBusBase<E, K, EventBus<E>> implements DispatchEventBus<E, K> {
-    public DispatchEventBusImpl(Class<E> eventType, DispatchKey<E, K> dispatchKey, Map<K, EventBus<E>> dispatched) {
+public final class DispatchEventBusImpl<E, K> extends DispatchEventBusBase<E, K, EventBusImpl<E>> implements DispatchEventBus<E, K> {
+    public DispatchEventBusImpl(Class<E> eventType, DispatchKey<E, K> dispatchKey, Map<K, EventBusImpl<E>> dispatched) {
         super(eventType, dispatchKey, dispatched);
     }
 
     @Override
-    protected EventBus<E> createBus(Class<E> eventType) {
-        return EventBus.create(eventType);
+    protected EventBusImpl<E> createBus(Class<E> eventType, K key) {
+        return new EventBusImpl<>(eventType, key);
     }
 }


### PR DESCRIPTION
- 在没有注册dispatch listener的情况下跳过创造key并把事件分发到dispatch bus的过程
- DispatchEventbus 的 `.unregister(token)` 可以准确匹配key，可以正确处理一个listener用两个key注册了两次在取消注册的情况
- 别小改动的可以看提交信息