### PR TITLE
registry infrastructure

### DIFF
--- a/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/api/registry/RegistryInfo.java
+++ b/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/api/registry/RegistryInfo.java
@@ -1,0 +1,31 @@
+package com.tkisor.nekojs.api.registry;
+
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * @author ZZZank
+ */
+public record RegistryInfo<T>(
+    Class<T> objectBaseType,
+    Type rawType,
+    ResourceKey<Registry<T>> resourceKey
+) {
+    public Optional<Registry<T>> getRegistry(RegistryAccess registryAccess) {
+        return registryAccess.lookup(resourceKey);
+    }
+
+    public Registry<T> getRegistryOrThrow(RegistryAccess registryAccess) {
+        var key = resourceKey;
+        return registryAccess.lookup(key).orElseThrow(() -> new IllegalStateException("No registry found for: " + key.identifier()));
+    }
+
+    public Identifier identifier() {
+        return resourceKey.identifier();
+    }
+}

--- a/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/api/registry/RegistryInfos.java
+++ b/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/api/registry/RegistryInfos.java
@@ -1,0 +1,89 @@
+package com.tkisor.nekojs.api.registry;
+
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.util.*;
+
+/**
+ * @author ZZZank
+ */
+public class RegistryInfos {
+    private final Map<Identifier, RegistryInfo<?>> infos = new HashMap<>();
+
+    /// @param classesToScan a list of classes, whose element will have its fields scanned and look for public static
+    /// final [ResourceKey] fields that represents a [Registry]. The [net.minecraft.core.registries.Registries] class
+    /// is a good example.
+    /// @param additionalInfos additional [RegistryInfo]s to be registered, usually from manual registration
+    public RegistryInfos(List<Class<?>> classesToScan, Collection<RegistryInfo<?>> additionalInfos) {
+        for (var c : classesToScan) {
+            for (var info : scanFromClass(c)) {
+                infos.put(info.resourceKey().identifier(), info);
+            }
+        }
+        for (var info : additionalInfos) {
+            infos.put(info.resourceKey().identifier(), info);
+        }
+    }
+
+    public Map<Identifier, RegistryInfo<?>> view() {
+        return Collections.unmodifiableMap(infos);
+    }
+
+    // example:
+    // public static final ResourceKey<Registry<Block>> BLOCK = createRegistryKey("block");
+    private ArrayList<RegistryInfo<?>> scanFromClass(Class<?> c) {
+        var result = new ArrayList<RegistryInfo<?>>();
+        for (var field : c.getDeclaredFields()) {
+            var modifiers = field.getModifiers();
+            if (
+                Modifier.isPublic(modifiers)
+                && Modifier.isStatic(modifiers)
+                && Modifier.isFinal(modifiers)
+                // ResourceKey
+                && field.getType() == ResourceKey.class
+                // ResourceKey<?>
+                && field.getGenericType() instanceof ParameterizedType parameterizedKey
+                // ResourceKey<A<B>>
+                && parameterizedKey.getActualTypeArguments()[0] instanceof ParameterizedType parameterizedReg
+                // ResourceKey<Registry<?>>
+                && parameterizedReg.getRawType() == Registry.class
+            ) {
+                // the ? in ResourceKey<Registry<?>>
+                var rawKeyType = parameterizedReg.getActualTypeArguments()[0];
+
+                // there multiple possibilities of Type:
+                // - Class: Block, String[], List
+                // - GenericArrayType: T[]
+                // - ParameterizedType: Codec<? extends Number>
+                // - TypeVariable: T, K
+                // - WildcardType: ?, ? extends String
+                // Only Class and ParameterizedType makes sense for registry key
+                Class<?> keyType;
+                if (rawKeyType instanceof Class<?> keyTypeClass) {
+                    keyType = keyTypeClass;
+                } else if (rawKeyType instanceof ParameterizedType keyTypeParameterized) {
+                    keyType = (Class<?>) keyTypeParameterized.getRawType();
+                } else {
+                    continue;
+                }
+
+                ResourceKey<?> key;
+                try {
+                    key = (ResourceKey<?>) field.get(null);
+                } catch (Exception _) {
+                    continue;
+                }
+
+                @SuppressWarnings("unchecked")
+                var built = new RegistryInfo<>((Class<Object>) keyType, rawKeyType, (ResourceKey<Registry<Object>>) key);
+                result.add(built);
+            }
+        }
+
+        return result;
+    }
+}

--- a/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/js/type_adapter/SimpleRegistryBasedAdapter.java
+++ b/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/js/type_adapter/SimpleRegistryBasedAdapter.java
@@ -1,0 +1,55 @@
+package com.tkisor.nekojs.js.type_adapter;
+
+import com.tkisor.nekojs.api.JSTypeAdapter;
+import com.tkisor.nekojs.api.data.NekoId;
+import graal.graalvm.polyglot.Value;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * @author ZZZank
+ */
+public record SimpleRegistryBasedAdapter<T>(Registry<T> registry, Class<T> targetType) implements JSTypeAdapter<T> {
+    @Override
+    public Class<T> getTargetClass() {
+        return targetType;
+    }
+
+    @Override
+    public boolean canConvert(Value value) {
+        if (value.isString()) {
+            return true;
+        }
+        if (value.isHostObject()) {
+            var hostObject = value.asHostObject();
+            return hostObject instanceof NekoId || hostObject instanceof Identifier;
+        }
+        return false;
+    }
+
+    @Override
+    public T convert(Value value) {
+        if (value.isString()) {
+            return getFromRegistry(value, Identifier.parse(value.asString()));
+        }
+        if (value.isHostObject()) {
+            var hostObject = value.asHostObject();
+            if (hostObject instanceof NekoId(String namespace, String path)) {
+                return getFromRegistry(value, Identifier.fromNamespaceAndPath(namespace, path));
+            } else if (hostObject instanceof Identifier identifier) {
+                return getFromRegistry(value, identifier);
+            }
+        }
+        return null;
+    }
+
+    private @NonNull T getFromRegistry(Value value, Identifier id) {
+        return registry.getOptional(id)
+            .orElseThrow(() -> new IllegalArgumentException(String.format(
+                "No object with id '%s' in registry '%s'",
+                value.asString(),
+                registry.key().identifier()
+            )));
+    }
+}


### PR DESCRIPTION
做了一个自动从类里扫描registry type的小玩意，将Registries和NeoforgeRegistries.Keys拿去扫描基本上就能拿到原版+neoforge所有registry。

以及一个为所有registry生效的fallback adapter。

目前只为26.1实现了这个功能，考虑到1.21到26.1这方面连类名都不变，迁移起来应该非常简单