### PR TITLE
update Graal to 25.1.3.6

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:6.0.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    // 25.0.2.2
-    implementation("curse.maven:graal-1504336:7983197")
+    // 25.1.3.6
+    api("curse.maven:graal-1504336:8456810")
 
     compileOnly 'org.jspecify:jspecify:1.0.0'
     compileOnly 'com.google.code.gson:gson:2.11.0'

--- a/common/src/main/java/com/tkisor/nekojs/NekoJS.java
+++ b/common/src/main/java/com/tkisor/nekojs/NekoJS.java
@@ -1,9 +1,11 @@
 package com.tkisor.nekojs;
 
+import com.tkisor.nekojs.core.NekoJSMemberRemapper;
 import com.tkisor.nekojs.core.ScriptEventBridge;
 import com.tkisor.nekojs.script.ScriptManager;
 import com.tkisor.nekojs.script.ScriptTypedValue;
 import com.tkisor.nekojs.script.prop.ScriptPropertyRegistry;
+import graal.mod.api.MemberRemapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -14,6 +16,10 @@ public class NekoJS {
     public final ScriptPropertyRegistry scriptProperties = new ScriptPropertyRegistry.Impl();
     public final ScriptTypedValue<ScriptManager> scriptManagers = ScriptTypedValue.of();
     public final ScriptEventBridge scriptEventBridge;
+
+    static {
+        MemberRemapper.CHAIN.addRemapper(new NekoJSMemberRemapper());
+    }
 
     public NekoJS(ScriptEventBridge scriptEventBridge) {
         this.scriptEventBridge = scriptEventBridge;

--- a/common/src/main/java/com/tkisor/nekojs/api/JavaMemberIndex.java
+++ b/common/src/main/java/com/tkisor/nekojs/api/JavaMemberIndex.java
@@ -105,10 +105,9 @@ public final class JavaMemberIndex {
      * @param hideMarker 命中 {@code @HideFromJS} 时的返回值。{@link MemberVisibilityQuery} 传 {@code null}
      *                   （表示从可见集合中剔除）；{@code NekoJSMemberRemapper} 传
      *                   {@code MemberRemapper.HIDE_MEMBER} 常量（满足 graal.mod.api SPI 约定）
-     * @param strict     {@code @RemapByPrefix} 剥离前缀时是否要求 {@code name.length() > prefix.length()}
-     *                   （{@link MemberVisibilityQuery} 传 true，避免空名；{@code NekoJSMemberRemapper} 传 false）
+     * @param fallThroughMarker 没有命中任何 remap 时的返回值。传入 {@link Member#getName()} 即相当于通常的 remapper 逻辑（有 remap 则使用，无则用原名）
      */
-    public static @Nullable String remapName(Member member, String hideMarker, boolean strict) {
+    public static @Nullable String remapName(Member member, String hideMarker, String fallThroughMarker) {
         AccessibleObject ao = (AccessibleObject) member;
 
         if (ao.isAnnotationPresent(HideFromJS.class)
@@ -125,25 +124,24 @@ public final class JavaMemberIndex {
 
         RemapByPrefix memberPrefix = ao.getAnnotation(RemapByPrefix.class);
         if (memberPrefix != null) {
-            String stripped = findAndRemovePrefix(original, memberPrefix.value(), strict);
+            String stripped = findAndRemovePrefix(original, memberPrefix.value());
             if (stripped != null) return stripped;
         }
 
         RemapByPrefix classPrefix = member.getDeclaringClass().getAnnotation(RemapByPrefix.class);
         if (classPrefix != null) {
-            String stripped = findAndRemovePrefix(original, classPrefix.value(), strict);
+            String stripped = findAndRemovePrefix(original, classPrefix.value());
             if (stripped != null) return stripped;
         }
 
-        return original;
+        return fallThroughMarker;
     }
 
     // ==================== 内部原语 ====================
 
-    private static @Nullable String findAndRemovePrefix(String name, String[] prefixes, boolean strict) {
+    private static @Nullable String findAndRemovePrefix(String name, String[] prefixes) {
         for (String prefix : prefixes) {
-            if (name.startsWith(prefix)) {
-                if (strict && name.length() <= prefix.length()) continue;
+            if (name.length() > prefix.length() && name.startsWith(prefix)) {
                 return name.substring(prefix.length());
             }
         }

--- a/common/src/main/java/com/tkisor/nekojs/api/MemberVisibilityQuery.java
+++ b/common/src/main/java/com/tkisor/nekojs/api/MemberVisibilityQuery.java
@@ -156,8 +156,7 @@ public final class MemberVisibilityQuery {
         return hierarchy;
     }
 
-    /** 委托 {@link JavaMemberIndex#remapName}：hideMarker=null（隐藏即从可见集合剔除），strict=true（前缀剥离需非空）。 */
     private static @Nullable String remapMember(Member member) {
-        return JavaMemberIndex.remapName(member, null, true);
+        return JavaMemberIndex.remapName(member, null, member.getName());
     }
 }

--- a/common/src/main/java/com/tkisor/nekojs/core/NekoJSMemberRemapper.java
+++ b/common/src/main/java/com/tkisor/nekojs/core/NekoJSMemberRemapper.java
@@ -15,12 +15,12 @@ import java.lang.reflect.Method;
 public class NekoJSMemberRemapper implements MemberRemapper {
 
     @Override
-    public String remapField(Field field) {
-        return JavaMemberIndex.remapName(field, MemberRemapper.HIDE_MEMBER, false);
+    public String remapField(Field field, Class<?> c) {
+        return JavaMemberIndex.remapName(field, MemberRemapper.HIDE_MEMBER, MemberRemapper.FALL_THROUGH);
     }
 
     @Override
-    public String remapMethod(Method method) {
-        return JavaMemberIndex.remapName(method, MemberRemapper.HIDE_MEMBER, false);
+    public String remapMethod(Method method, Class<?> c) {
+        return JavaMemberIndex.remapName(method, MemberRemapper.HIDE_MEMBER, MemberRemapper.FALL_THROUGH);
     }
 }

--- a/platforms/neoforge-1.21.1/build.gradle
+++ b/platforms/neoforge-1.21.1/build.gradle
@@ -98,7 +98,6 @@ neoForge {
 dependencies {
     implementation project(':common')
 
-    implementation("curse.maven:graal-1504336:7983197")
     implementation "curse.maven:jei-238222:7420587"
 
     compileOnly 'org.projectlombok:lombok:1.18.44'
@@ -164,14 +163,14 @@ unifiedPublishing {
             }
         }
 
-        if (ENV.CURSEFORGE_KEY) {
+        if (ENV.CURSEFORGE_KEY && project.hasProperty('curseforge_id')) {
             curseforge {
                 token = ENV.CURSEFORGE_KEY
                 id = project.curseforge_id
             }
         }
 
-        if (ENV.MODRINTH_TOKEN) {
+        if (ENV.MODRINTH_TOKEN && project.hasProperty('modrinth_id')) {
             modrinth {
                 token = ENV.MODRINTH_TOKEN
                 id = project.modrinth_id

--- a/platforms/neoforge-1.21.1/src/main/java/com/tkisor/nekojs/NekoJSMod.java
+++ b/platforms/neoforge-1.21.1/src/main/java/com/tkisor/nekojs/NekoJSMod.java
@@ -4,7 +4,6 @@ import com.tkisor.nekojs.bindings.event.GoalEvents;
 import com.tkisor.nekojs.bindings.static_access.ScriptEventsJS;
 import com.tkisor.nekojs.client.NekoJSClient;
 import com.tkisor.nekojs.command.NekoJSCommands;
-import com.tkisor.nekojs.core.NekoJSMemberRemapper;
 import com.tkisor.nekojs.core.NeoForgePluginLoader;
 import com.tkisor.nekojs.core.NeoForgeRuntimeBootstrap;
 import com.tkisor.nekojs.core.NekoSandboxFactory;
@@ -20,7 +19,6 @@ import com.tkisor.nekojs.core.fs.NekoJSPaths;
 import com.tkisor.nekojs.core.lifecycle.NekoRuntimeRoot;
 import com.tkisor.nekojs.core.NekoSharedEngine;
 import com.tkisor.nekojs.api.compiler.ScriptCompilerRegistry;
-import graal.mod.api.MemberRemapper;
 import com.tkisor.nekojs.platform.NekoIdCompat;
 import com.tkisor.nekojs.platform.NeoForgeIdCompat;
 import com.tkisor.nekojs.network.ScriptSyncService;
@@ -32,7 +30,6 @@ import com.tkisor.nekojs.core.plugin.NekoPluginRuntime;
 import com.tkisor.nekojs.api.plugin.NekoRuntimeAccess;
 import com.tkisor.nekojs.listener.RegistryEventListener;
 import com.tkisor.nekojs.script.ScriptBootstrap;
-import com.tkisor.nekojs.script.ScriptManager;
 import com.tkisor.nekojs.script.ScriptType;
 import com.tkisor.nekojs.script.WorkspaceGenerator;
 import net.neoforged.api.distmarker.Dist;
@@ -51,7 +48,6 @@ public class NekoJSMod extends NekoJS {
     private final ScriptEventsJS scriptEventsRegistrar;
 
     static {
-        MemberRemapper.GLOBAL.set(new NekoJSMemberRemapper());
         Platform.init(new NeoForgePlatform());
         NekoIdCompat.init(new NeoForgeIdCompat());
     }

--- a/platforms/neoforge-26.1/build.gradle
+++ b/platforms/neoforge-26.1/build.gradle
@@ -90,7 +90,6 @@ neoForge {
 dependencies {
     implementation project(':common')
 
-    implementation("curse.maven:graal-1504336:7983197")
     implementation "curse.maven:jei-238222:7920926"
 
     compileOnly 'org.projectlombok:lombok:1.18.44'
@@ -159,7 +158,7 @@ unifiedPublishing {
         }
 
         // 配置 CurseForge 发布
-        if (ENV.CURSEFORGE_KEY) {
+        if (ENV.CURSEFORGE_KEY && project.hasProperty('curseforge_id')) {
             curseforge {
                 token = ENV.CURSEFORGE_KEY
                 // 你的项目 ID (数字)，需要在 gradle.properties 中添加 `curseforge_id=xxxxxx`
@@ -168,7 +167,7 @@ unifiedPublishing {
         }
 
         // 配置 Modrinth 发布
-        if (ENV.MODRINTH_TOKEN) {
+        if (ENV.MODRINTH_TOKEN && project.hasProperty('modrinth_id')) {
             modrinth {
                 token = ENV.MODRINTH_TOKEN
                 // 你的项目 ID (字符串)，需要在 gradle.properties 中添加 `modrinth_id=xxxxxx`

--- a/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/NekoJSMod.java
+++ b/platforms/neoforge-26.1/src/main/java/com/tkisor/nekojs/NekoJSMod.java
@@ -4,7 +4,6 @@ import com.tkisor.nekojs.bindings.event.GoalEvents;
 import com.tkisor.nekojs.bindings.static_access.ScriptEventsJS;
 import com.tkisor.nekojs.client.NekoJSClient;
 import com.tkisor.nekojs.command.NekoJSCommands;
-import com.tkisor.nekojs.core.NekoJSMemberRemapper;
 import com.tkisor.nekojs.core.NeoForgePluginLoader;
 import com.tkisor.nekojs.core.NeoForgeRuntimeBootstrap;
 import com.tkisor.nekojs.core.NekoSandboxFactory;
@@ -20,7 +19,6 @@ import com.tkisor.nekojs.core.fs.NekoJSPaths;
 import com.tkisor.nekojs.core.lifecycle.NekoRuntimeRoot;
 import com.tkisor.nekojs.core.NekoSharedEngine;
 import com.tkisor.nekojs.api.compiler.ScriptCompilerRegistry;
-import graal.mod.api.MemberRemapper;
 import com.tkisor.nekojs.platform.NekoIdCompat;
 import com.tkisor.nekojs.platform.NeoForgeIdCompat;
 import com.tkisor.nekojs.network.ScriptSyncService;
@@ -32,10 +30,8 @@ import com.tkisor.nekojs.core.plugin.NekoPluginRuntime;
 import com.tkisor.nekojs.api.plugin.NekoRuntimeAccess;
 import com.tkisor.nekojs.listener.RegistryEventListener;
 import com.tkisor.nekojs.script.ScriptBootstrap;
-import com.tkisor.nekojs.script.ScriptManager;
 import com.tkisor.nekojs.script.ScriptType;
 import com.tkisor.nekojs.script.WorkspaceGenerator;
-import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
@@ -44,8 +40,6 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.entity.player.PlayerEvent;
-import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
 @Mod(NekoJS.MODID)
 public class NekoJSMod extends NekoJS {
@@ -54,7 +48,6 @@ public class NekoJSMod extends NekoJS {
     private final ScriptEventsJS scriptEventsRegistrar;
 
     static {
-        MemberRemapper.GLOBAL.set(new NekoJSMemberRemapper());
         Platform.init(new NeoForgePlatform());
         NekoIdCompat.init(new NeoForgeIdCompat());
     }

--- a/platforms/neoforge-26.2/build.gradle
+++ b/platforms/neoforge-26.2/build.gradle
@@ -90,7 +90,6 @@ neoForge {
 dependencies {
     implementation project(':common')
 
-    implementation("curse.maven:graal-1504336:7983197")
     // 30.1.0.12 for NeoForge 26.2
     implementation "curse.maven:jei-238222:8300448"
 
@@ -160,7 +159,7 @@ unifiedPublishing {
         }
 
         // 配置 CurseForge 发布
-        if (ENV.CURSEFORGE_KEY) {
+        if (ENV.CURSEFORGE_KEY && project.hasProperty('curseforge_id')) {
             curseforge {
                 token = ENV.CURSEFORGE_KEY
                 // 你的项目 ID (数字)，需要在 gradle.properties 中添加 `curseforge_id=xxxxxx`
@@ -169,7 +168,7 @@ unifiedPublishing {
         }
 
         // 配置 Modrinth 发布
-        if (ENV.MODRINTH_TOKEN) {
+        if (ENV.MODRINTH_TOKEN && project.hasProperty('modrinth_id')) {
             modrinth {
                 token = ENV.MODRINTH_TOKEN
                 // 你的项目 ID (字符串)，需要在 gradle.properties 中添加 `modrinth_id=xxxxxx`

--- a/platforms/neoforge-26.2/src/main/java/com/tkisor/nekojs/NekoJSMod.java
+++ b/platforms/neoforge-26.2/src/main/java/com/tkisor/nekojs/NekoJSMod.java
@@ -4,7 +4,6 @@ import com.tkisor.nekojs.bindings.event.GoalEvents;
 import com.tkisor.nekojs.bindings.static_access.ScriptEventsJS;
 import com.tkisor.nekojs.client.NekoJSClient;
 import com.tkisor.nekojs.command.NekoJSCommands;
-import com.tkisor.nekojs.core.NekoJSMemberRemapper;
 import com.tkisor.nekojs.core.NeoForgePluginLoader;
 import com.tkisor.nekojs.core.NeoForgeRuntimeBootstrap;
 import com.tkisor.nekojs.core.NekoSandboxFactory;
@@ -20,7 +19,6 @@ import com.tkisor.nekojs.core.fs.NekoJSPaths;
 import com.tkisor.nekojs.core.lifecycle.NekoRuntimeRoot;
 import com.tkisor.nekojs.core.NekoSharedEngine;
 import com.tkisor.nekojs.api.compiler.ScriptCompilerRegistry;
-import graal.mod.api.MemberRemapper;
 import com.tkisor.nekojs.platform.NekoIdCompat;
 import com.tkisor.nekojs.platform.NeoForgeIdCompat;
 import com.tkisor.nekojs.network.ScriptSyncService;
@@ -32,7 +30,6 @@ import com.tkisor.nekojs.core.plugin.NekoPluginRuntime;
 import com.tkisor.nekojs.api.plugin.NekoRuntimeAccess;
 import com.tkisor.nekojs.listener.RegistryEventListener;
 import com.tkisor.nekojs.script.ScriptBootstrap;
-import com.tkisor.nekojs.script.ScriptManager;
 import com.tkisor.nekojs.script.ScriptType;
 import com.tkisor.nekojs.script.WorkspaceGenerator;
 import net.neoforged.api.distmarker.Dist;
@@ -51,7 +48,6 @@ public class NekoJSMod extends NekoJS {
     private final ScriptEventsJS scriptEventsRegistrar;
 
     static {
-        MemberRemapper.GLOBAL.set(new NekoJSMemberRemapper());
         Platform.init(new NeoForgePlatform());
         NekoIdCompat.init(new NeoForgeIdCompat());
     }


### PR DESCRIPTION
新版 Graal 其实还带有另一个新功能，可以注册一个typemapping的“工厂”，根据需要mapping的class动态提供typemapping，但是现在这种又runtime又bootstrap的架构下写起来怪麻烦的，什么时候叫AI写吧。相关class: graal.mod.api.TypeMappingProvider, graal.mod.api.TypeMappingProviderRegistry